### PR TITLE
Add support for `j`, `jal` and `addi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # University of Waterloo MIPS Support
 
-This VSCode extension provides basic MIPS colorization and snippets support for the flavour of MIPS taught in the University of Waterloo's CS courses.
+This VSCode extension provides basic MIPS colorization and snippets support for the flavour of MIPS taught in the University of Waterloo's CS241 and CS230 courses.
 
 ### Colors
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # University of Waterloo MIPS Support
 
-This VSCode extension provides basic MIPS colorization and snippets support for the flavour of MIPS taught in the University of Waterloo's CS241 course.
+This VSCode extension provides basic MIPS colorization and snippets support for the flavour of MIPS taught in the University of Waterloo's CS courses.
 
 ### Colors
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "mips-uwaterloo",
   "displayName": "UWaterloo MIPS Support",
-  "description": "Provides syntax highlighting and snippets for MIPS assembly language used in the University of Waterloo's CS241 course.",
+  "description": "Provides syntax highlighting and snippets for MIPS assembly language used in the University of Waterloo's CS courses.",
   "publisher": "qhyun-uwaterloo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "vscode": "^1.52.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mips-uwaterloo",
   "displayName": "UWaterloo MIPS Support",
-  "description": "Provides syntax highlighting and snippets for MIPS assembly language used in the University of Waterloo's CS courses.",
+  "description": "Provides syntax highlighting and snippets for MIPS assembly language used in the University of Waterloo's CS241 and CS230 courses.",
   "publisher": "qhyun-uwaterloo",
   "version": "1.0.1",
   "engines": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -95,10 +95,22 @@
     "description": "Branch on Not Equal",
     "scope": "source.mips"
   },
+  "j": {
+    "prefix": "j",
+    "body": "j ${1:i} ; pc = $1\n",
+    "description": "Jump",
+    "scope": "source.mips"
+  },
   "jr": {
     "prefix": "jr",
     "body": "jr $${1:31} ; pc = $${1:31}",
     "description": "Jump Register",
+    "scope": "source.mips"
+  },
+  "jal": {
+    "prefix": "jal",
+    "body": "jal ${1:i} ; \\$31 = pc and \\$pc = $1\n",
+    "description": "Jump And Link",
     "scope": "source.mips"
   },
   "jalr": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -11,6 +11,12 @@
     "description": "Add",
     "scope": "source.mips"
   },
+  "addi": {
+    "prefix": "addi",
+    "body": "addi $${1:t}, $${2:s}, ${3:i} ; $$1 = $$2 + $3\n",
+    "description": "Add Immediate",
+    "scope": "source.mips"
+  },
   "sub": {
     "prefix": "sub",
     "body": "sub $${1:d}, $${2:s}, $${3:t} ; $$1 = $$2 - $$3\n",

--- a/syntaxes/mips.tmLanguage.json
+++ b/syntaxes/mips.tmLanguage.json
@@ -5,7 +5,7 @@
   "patterns": [
     {
       "name": "support.function.mips",
-      "match": "\\b(add|sub|mult|multu|div|divu|mfhi|mflo|lis|lw|sw|slt|sltu|beq|bne|jr|jalr)\\b"
+      "match": "\\b(add|sub|mult|multu|div|divu|mfhi|mflo|lis|lw|sw|slt|sltu|beq|bne|j|jr|jal|jalr)\\b"
     },
     { "name": "storage.type.mips", "match": ".word\\b" },
     { "captures": { "1": { "name": "entity.name.mips" } }, "name": "entity.name.mips", "match": "\\b([A-Za-z0-9_]+):" },

--- a/syntaxes/mips.tmLanguage.json
+++ b/syntaxes/mips.tmLanguage.json
@@ -5,7 +5,7 @@
   "patterns": [
     {
       "name": "support.function.mips",
-      "match": "\\b(add|sub|mult|multu|div|divu|mfhi|mflo|lis|lw|sw|slt|sltu|beq|bne|j|jr|jal|jalr)\\b"
+      "match": "\\b(add|addi|sub|mult|multu|div|divu|mfhi|mflo|lis|lw|sw|slt|sltu|beq|bne|j|jr|jal|jalr)\\b"
     },
     { "name": "storage.type.mips", "match": ".word\\b" },
     { "captures": { "1": { "name": "entity.name.mips" } }, "name": "entity.name.mips", "match": "\\b([A-Za-z0-9_]+):" },


### PR DESCRIPTION
- Added syntax highlighting support and snippets for `j`, `jal` and `addi` instructions.
- I found this extension also helpful for some other CS courses (eg. CS 230)

#### References:
https://student.cs.uwaterloo.ca/~cs230/s23/lecture_slides/mipsref.pdf